### PR TITLE
crates: add 'mention' crate

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,6 +12,7 @@
     - [Twilight](./chapter_1_crates/section_6_twilight.md)
     - [First-party](./chapter_1_crates/section_7_first_party/summary.md)
         - [Lavalink](./chapter_1_crates/section_7_first_party/section_2_lavalink.md)
+        - [Mention](./chapter_1_crates/section_7_first_party/section_3_mention.md)
     - [Third-party](./chapter_1_crates/section_8_third_party.md)
 - [Building a Bot](./chapter_2_building_a_bot/summary.md)
     - [Preparation](./chapter_2_building_a_bot/section_1_preparation.md)

--- a/src/chapter_1_crates/section_7_first_party/section_3_mention.md
+++ b/src/chapter_1_crates/section_7_first_party/section_3_mention.md
@@ -1,0 +1,38 @@
+# Lavalink
+
+`twilight-mention` is a utility crate to mention [`twilight-model`] types.
+
+With this library, you can create mentions for various types, such as users,
+emojis, roles, members, or channels.
+
+### Installation
+
+This library requires at least Rust 1.45.0+.
+
+Add the following to your `Cargo.toml`:
+
+```toml
+twilight-mention = { branch = "trunk", git = "https://github.com/twilight-rs/twilight" }
+```
+
+### Examples
+
+Create a mention formatter for a user ID, and then format it in a message:
+
+```rust
+use twilight_mention::Mention;
+use twilight_model::id::UserId;
+
+let user_id = UserId(123);
+let message = format!("Hey there, {}!", user_id.mention());
+```
+
+### Links
+
+*source*: <https://github.com/twilight-rs/twilight/tree/trunk/utils/mention>
+
+*docs*: <https://twilight-rs.github.io/twilight/twilight_mention/index.html>
+
+*crates.io*: <https://crates.io/crates/twilight-mention>
+
+[`twilight-model`]: ../section_1_model.html


### PR DESCRIPTION
Add the recent `twilight-mention` crate, which creates formatters for `twilight-model` types to mention them.