### PR TITLE
bots_using_twilight: update link to http client

### DIFF
--- a/src/chapter_3_bots_using_twilight.md
+++ b/src/chapter_3_bots_using_twilight.md
@@ -1,7 +1,7 @@
 # Bots using Twilight
 
-Below is a list of bots known to be using the Twilight ecosystem. The use could be
-as small as only [the gateway] or [HTTP proxy], or as large as all of the
+Below is a list of bots known to be using the Twilight ecosystem. The use could
+be as small as only [the gateway] or [HTTP client], or as large as all of the
 [core crates].
 
 Want your bot added? Feel free to send a PR to the [repo]!
@@ -19,7 +19,7 @@ Lasagne bot is a bot that posts garfield comics.
 
 *Source*: [Sr.ht][bot:lasagna:source]
 
-[HTTP proxy]: ./chapter_3_services/section_2_using_http_proxy.html
+[HTTP client]: ./chapter_1_crates/section_2_http.html
 [core crates]: ./chapter_1_crates/summary.html
 [repo]: https://github.com/twilight-rs/twilight-rs.github.io
 [the gateway]: ./chapter_1_crates/section_3_gateway.html


### PR DESCRIPTION
Update the link in the "Bots using Twilight" section to link to a crate, the http client, instead of a showcase service.

(also, the link 404d.)