### PR TITLE
Change the publish branch to "rendered"

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,5 +23,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book
-          publish_branch: master
+          publish_branch: rendered
           cname: twilight.rs


### PR DESCRIPTION
GitHub have now fixed it so you can have an arbitary publish branch on organization `.github.io` repos.

**Note**: on merge change the branch in the settings