### PR TITLE
Fix all examples and use skeptic to test them via CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+      docs
+  pull_request:
+
+jobs:
+  test:
+    name: Test examples with skeptic
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Test
+        run: cargo test --manifest-path tests/Cargo.toml

--- a/src/chapter_1_crates/section_2_http.md
+++ b/src/chapter_1_crates/section_2_http.md
@@ -20,7 +20,7 @@ twilight-http = "0.1"
 A quick example showing how to send 10 messages, and then print the current
 user's name:
 
-```rust
+```rust,no_run
 use futures::future;
 use std::{env, error::Error};
 use twilight_http::Client;

--- a/src/chapter_1_crates/section_3_gateway.md
+++ b/src/chapter_1_crates/section_3_gateway.md
@@ -13,8 +13,14 @@ shards and unify their messages into one stream. It doesn't have a large API, yo
 usually want to spawn a task to bring it up such that you can begin to receive
 tasks as soon as they arrive.
 
-```rust
-let cluster = Cluster::new(config).await?;
+```rust,no_run
+# use futures::StreamExt;
+# use twilight_gateway::Cluster;
+#
+# #[tokio::main]
+# async fn main() -> Result<(), Box<dyn std::error::Error>> {
+#    let token = "dummy";
+let cluster = Cluster::new(token).await?;
 
 let mut events = cluster.events();
 
@@ -23,6 +29,9 @@ let cluster_spawn = cluster.clone();
 tokio::spawn(async move {
     cluster_spawn.up().await;
 });
+# let _ = events.next().await {
+#     Ok(())
+# }
 ```
 
 ## Installation
@@ -66,7 +75,7 @@ the dependency tree it will make use of that instead of [zlib-ng].
 
 Starting a `Shard` and printing the contents of new messages as they come in:
 
-```rust
+```rust,no_run
 use futures::StreamExt;
 use std::{env, error::Error};
 use twilight_gateway::Shard;

--- a/src/chapter_1_crates/section_3_gateway.md
+++ b/src/chapter_1_crates/section_3_gateway.md
@@ -29,7 +29,7 @@ let cluster_spawn = cluster.clone();
 tokio::spawn(async move {
     cluster_spawn.up().await;
 });
-# let _ = events.next().await {
+# let _ = events.next().await;
 #     Ok(())
 # }
 ```

--- a/src/chapter_1_crates/section_4_cache_inmemory.md
+++ b/src/chapter_1_crates/section_4_cache_inmemory.md
@@ -16,15 +16,17 @@ twilight-cache-inmemory = "0.1"
 
 Process items that come over a shard into the cache:
 
-```rust
-use futures::stream::StreamExt;
+```rust,no_run
+# #[tokio::main]
+# async fn main() -> Result<(), Box<dyn std::error::Error>> {
+use futures::StreamExt;
 use std::env;
 use twilight_cache_inmemory::InMemoryCache;
 use twilight_gateway::Shard;
 
 let token = env::var("DISCORD_TOKEN")?;
 
-let shard = Shard::new(token);
+let mut shard = Shard::new(token);
 shard.start().await?;
 
 let cache = InMemoryCache::new();
@@ -32,8 +34,10 @@ let cache = InMemoryCache::new();
 let mut events = shard.events();
 
 while let Some(event) = events.next().await {
-    cache.process(&event);
+    cache.update(&event);
 }
+#     Ok(())
+# }
 ```
 
 ## Links

--- a/src/chapter_1_crates/section_5_command_parser.md
+++ b/src/chapter_1_crates/section_5_command_parser.md
@@ -27,14 +27,15 @@ twilight-command-parser = "0.1"
 A simple parser for a bot with one prefix (`"!"`) and two commands, `"echo"`
 and `"ping"`:
 
-```rust
-use twilight_command_parser::{Command, Config, Parser};
+```rust,no_run
+# fn main() {
+use twilight_command_parser::{Command, CommandParserConfig, Parser};
 
-let mut config = Config::new();
+let mut config = CommandParserConfig::new();
 
 // (Use `Config::add_command` to add a single command)
-config.command("echo").add();
-config.command("ping").add();
+config.add_command("echo", true);
+config.add_command("ping", true);
 
 // Add the prefix `"!"`.
 // (Use `Config::add_prefixes` to add multiple prefixes)
@@ -56,6 +57,7 @@ match parser.parse("!echo a message") {
     Some(_) => {},
     None => println!("Message didn't match a prefix and command"),
 }
+# }
 ```
 
 ## Links

--- a/src/chapter_1_crates/section_6_standby.md
+++ b/src/chapter_1_crates/section_6_standby.md
@@ -19,7 +19,10 @@ twilight-standby = "0.1"
 
 Wait for a message in channel 123 by user 456 with the content "test":
 
-```rust
+```rust,no_run
+# #[allow(unused_variables)]
+# #[tokio::main]
+# async fn main() -> Result<(), Box<dyn std::error::Error>> {
 use twilight_model::{gateway::payload::MessageCreate, id::{ChannelId, UserId}};
 use twilight_standby::Standby;
 
@@ -29,6 +32,8 @@ let standby = Standby::new();
 let message = standby.wait_for_message(ChannelId(123), |event: &MessageCreate| {
     event.author.id == UserId(456) && event.content == "test"
 }).await?;
+#     Ok(())
+# }
 ```
 
 ## Links

--- a/src/chapter_1_crates/section_7_first_party/section_1_embed_builder.md
+++ b/src/chapter_1_crates/section_7_first_party/section_1_embed_builder.md
@@ -19,6 +19,8 @@ twilight-embed-builder = "0.1"
 Build a simple embed:
 
 ```rust
+# #[allow(unused_variables)]
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder};
 
 let embed = EmbedBuilder::new()
@@ -26,17 +28,23 @@ let embed = EmbedBuilder::new()
     .field(EmbedFieldBuilder::new("Wings", "She has wings.")?.inline())
     .field(EmbedFieldBuilder::new("Horn", "She can do magic, and she's really good at it.")?.inline())
     .build();
+#     Ok(())
+# }
 ```
 
 Build an embed with an image:
 
 ```rust
+# #[allow(unused_variables)]
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 use twilight_embed_builder::{EmbedBuilder, ImageSource};
 
 let embed = EmbedBuilder::new()
     .description("Here's a cool image of Twilight Sparkle")?
     .image(ImageSource::attachment("bestpony.png")?)
     .build();
+#     Ok(())
+# }
 ```
 
 ## Links

--- a/src/chapter_1_crates/section_7_first_party/section_2_mention.md
+++ b/src/chapter_1_crates/section_7_first_party/section_2_mention.md
@@ -18,11 +18,14 @@ twilight-mention = "0.1"
 Create a mention formatter for a user ID, and then format it in a message:
 
 ```rust
+# #[allow(unused_variables)]
+# fn main() {
 use twilight_mention::Mention;
 use twilight_model::id::UserId;
 
 let user_id = UserId(123);
 let message = format!("Hey there, {}!", user_id.mention());
+# }
 ```
 
 ## Links

--- a/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
+++ b/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
@@ -21,7 +21,7 @@ twilight-lavalink = "0.1"
 Create a [client], add a [node], and give events to the client to [process]
 events:
 
-```rust
+```rust,no_run
 use futures::StreamExt;
 use std::{
     env,

--- a/src/chapter_1_crates/section_7_first_party/section_4_util.md
+++ b/src/chapter_1_crates/section_7_first_party/section_4_util.md
@@ -15,11 +15,14 @@ twilight-util = { features = ["snowflake"], version = "0.1" }
 ## Examples
 The snowflake trait can be used like this
 ```rust
+# #[allow(unused_variables)]
+# fn main() {
 use twilight_util::snowflake::Snowflake;
 use twilight_model::id::UserId;
 
 let user = UserId(123456);
 let timestamp = user.timestamp();
+# }
 ```
 
 ## Links

--- a/src/overview.md
+++ b/src/overview.md
@@ -45,7 +45,7 @@ There is a community and support server [on Discord][server].
 Below is a quick example of a program printing "Pong!" when a ping command comes
 in from a channel:
 
-```rust
+```rust,no_run
 use std::{env, error::Error};
 use tokio::stream::StreamExt;
 use twilight_cache_inmemory::{EventType, InMemoryCache};

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "twilight-book"
+version = "0.1.0"
+authors = ["Twilight Contributors"]
+edition = "2018"
+
+[dependencies]
+futures = { version = "0.3", default-features = false }
+# skeptic = "0.13" # is broken
+# see https://github.com/budziq/rust-skeptic/issues/120
+skeptic = { git = 'https://github.com/andygauge/rust-skeptic'}
+tokio = { version = "0.2", features = ["full"] }
+twilight-gateway = { version = "0.1" }
+twilight-http = { version = "0.1" }
+twilight-model = { version = "0.1" }
+twilight-lavalink = { version = "0.1" }
+twilight-cache-inmemory = { version = "0.1" }
+twilight-command-parser = { version = "0.1" }
+twilight-embed-builder = { version = "0.1" }
+twilight-mention = { version = "0.1" }
+twilight-standby = { version = "0.1" }
+twilight-util = { version = "0.1", features = ["snowflake"] }
+
+tracing-subscriber = "0.2"
+
+[build-dependencies]
+# skeptic = "0.13"
+skeptic = { git = 'https://github.com/andygauge/rust-skeptic'}
+

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let files = skeptic::markdown_files_of_directory("../src/")
+        .into_iter()
+        .collect::<Vec<_>>();
+    skeptic::generate_doc_tests(&files);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -1,0 +1,3 @@
+#![deny(warnings)]
+
+include!(concat!(env!("OUT_DIR"), "/skeptic-tests.rs"));


### PR DESCRIPTION
By default skeptic requires all examples to have a `main` function and
will remove preceding `#` like rustdoc.