### PR TITLE
crates: link to docs.rs for crate docs

### DIFF
--- a/src/chapter_1_crates/section_1_model.md
+++ b/src/chapter_1_crates/section_1_model.md
@@ -37,7 +37,7 @@ twilight-model = "0.1"
 
 *source*: <https://github.com/twilight-rs/twilight/tree/master/model>
 
-*docs*: <https://twilight-rs.github.io/twilight/twilight_model/index.html>
+*docs*: <https://docs.rs/twilight-model>
 
 *crates.io*: <https://crates.io/crates/twilight-model>
 

--- a/src/chapter_1_crates/section_2_http.md
+++ b/src/chapter_1_crates/section_2_http.md
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
 *source*: <https://github.com/twilight-rs/twilight/tree/trunk/http>
 
-*docs*: <https://twilight-rs.github.io/twilight/twilight_http/index.html>
+*docs*: <https://docs.rs/twilight-http>
 
 *crates.io*: <https://crates.io/crates/twilight-http>
 

--- a/src/chapter_1_crates/section_3_gateway.md
+++ b/src/chapter_1_crates/section_3_gateway.md
@@ -61,14 +61,14 @@ You can also use the environment variable `RUSTFLAGS="-C target-cpu=native"`.
 
 ### Zlib
 
-`stock-zlib` makes [flate2] use the stock-zlib which is either upstream or the 
+`stock-zlib` makes [flate2] use the stock-zlib which is either upstream or the
 one included with the operating system.
 
-`simd-zlib` enables the use of [zlib-ng] which is a modern fork of zlib that in 
+`simd-zlib` enables the use of [zlib-ng] which is a modern fork of zlib that in
 most cases will be more effective. Though it will add an externel dependency on
 [cmake].
 
-If both are enabled or if the `zlib` feature of [flate2] is enabled anywhere in 
+If both are enabled or if the `zlib` feature of [flate2] is enabled anywhere in
 the dependency tree it will make use of that instead of [zlib-ng].
 
 ## Example
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
 *source*: <https://github.com/twilight-rs/twilight/tree/trunk/gateway>
 
-*docs*: <https://twilight-rs.github.io/twilight/twilight_gateway/index.html>
+*docs*: <https://docs.rs/twilight-gateway>
 
 *crates.io*: <https://crates.io/crates/twilight-gateway>
 

--- a/src/chapter_1_crates/section_6_standby.md
+++ b/src/chapter_1_crates/section_6_standby.md
@@ -40,6 +40,6 @@ let message = standby.wait_for_message(ChannelId(123), |event: &MessageCreate| {
 
 *source*: <https://github.com/twilight-rs/twilight/tree/trunk/standby>
 
-*docs*: <https://twilight-rs.github.io/twilight/twilight_standby/index.html>
+*docs*: <https://docs.rs/twilight-standby>
 
 *crates.io*: <https://crates.io/crates/twilight-standby>

--- a/src/chapter_1_crates/section_7_first_party/section_1_embed_builder.md
+++ b/src/chapter_1_crates/section_7_first_party/section_1_embed_builder.md
@@ -51,6 +51,6 @@ let embed = EmbedBuilder::new()
 
 *source*: <https://github.com/twilight-rs/twilight/tree/trunk/utils/embed-builder>
 
-*docs*: <https://twilight-rs.github.io/twilight/twilight_embed_builder/index.html>
+*docs*: <https://docs.rs/twilight-embed-builder>
 
 *crates.io*: <https://crates.io/crates/twilight-embed-builder>

--- a/src/chapter_1_crates/section_7_first_party/section_2_mention.md
+++ b/src/chapter_1_crates/section_7_first_party/section_2_mention.md
@@ -32,7 +32,7 @@ let message = format!("Hey there, {}!", user_id.mention());
 
 *source*: <https://github.com/twilight-rs/twilight/tree/trunk/utils/mention>
 
-*docs*: <https://twilight-rs.github.io/twilight/twilight_mention/index.html>
+*docs*: <https://docs.rs/twilight-mention>
 
 *crates.io*: <https://crates.io/crates/twilight-mention>
 

--- a/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
+++ b/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
 
 **source**: <https://github.com/twilight-rs/twilight/tree/trunk/lavalink>
 
-**docs**: <https://twilight-rs.github.io/twilight/twilight_lavalink/index.html>
+**docs**: <https://docs.rs/twilight-lavalink>
 
 **crates.io**: <https://crates.io/crates/twilight-lavalink>
 

--- a/src/chapter_1_crates/section_7_first_party/section_4_util.md
+++ b/src/chapter_1_crates/section_7_first_party/section_4_util.md
@@ -29,6 +29,6 @@ let timestamp = user.timestamp();
 
 *source*: <https://github.com/twilight-rs/twilight/tree/trunk/util>
 
-*docs*: <https://api.twilight.rs/twilight_util/index.html>
+*docs*: <https://docs.rs/twilight-util>
 
 *crates.io*: <https://crates.io/crates/twilight-util>

--- a/src/chapter_1_crates/section_7_first_party/section_5_gateway_queue.md
+++ b/src/chapter_1_crates/section_7_first_party/section_5_gateway_queue.md
@@ -15,7 +15,7 @@ twilight-gateway-queue = "0.1.0"
 
 *source*: <https://github.com/twilight-rs/twilight/tree/trunk/gateway/queue>
 
-*docs*: <https://api.twilight.rs/twilight_gateway_queue/index.html>
+*docs*: <https://docs.rs/twilight-gateway-queue>
 
 *crates.io*: <https://crates.io/crates/twilight-gateway-queue>
 


### PR DESCRIPTION
Instead of linking between a combination of docs.rs and twilight-rs.github.io/twilight for crates' documentation, link only to each crate's docs.rs documentation.