### PR TITLE
crates: remove installation notes

### DIFF
--- a/src/chapter_1_crates/section_1_model.md
+++ b/src/chapter_1_crates/section_1_model.md
@@ -25,14 +25,6 @@ and returned by the gateway API. `guild` contains types owned by the Guild
 resource category. These types may be directly returned by, built on top of,
 or extended by other Twilight crates.
 
-## Installation
-
-Add the following to your `Cargo.toml`:
-
-```toml
-twilight-model = "0.1"
-```
-
 ## Links
 
 *source*: <https://github.com/twilight-rs/twilight/tree/master/model>

--- a/src/chapter_1_crates/section_2_http.md
+++ b/src/chapter_1_crates/section_2_http.md
@@ -7,14 +7,6 @@ but it can be changed to use NativeTLS which uses the TLS native to the platform
 
 Ratelimiting is included out-of-the-box, along with support for proxies.
 
-## Installation
-
-Add the following to your `Cargo.toml`:
-
-```toml
-twilight-http = "0.1"
-```
-
 ## Example
 
 A quick example showing how to send 10 messages, and then print the current

--- a/src/chapter_1_crates/section_3_gateway.md
+++ b/src/chapter_1_crates/section_3_gateway.md
@@ -34,14 +34,6 @@ tokio::spawn(async move {
 # }
 ```
 
-## Installation
-
-Add the following to your `Cargo.toml`:
-
-```toml
-twilight-gateway = "0.1"
-```
-
 ## Features
 
 `twilight-gateway` includes a few features `simd-json` for enabling faster json
@@ -61,14 +53,14 @@ You can also use the environment variable `RUSTFLAGS="-C target-cpu=native"`.
 
 ### Zlib
 
-`stock-zlib` makes [flate2] use the stock-zlib which is either upstream or the 
+`stock-zlib` makes [flate2] use the stock-zlib which is either upstream or the
 one included with the operating system.
 
-`simd-zlib` enables the use of [zlib-ng] which is a modern fork of zlib that in 
+`simd-zlib` enables the use of [zlib-ng] which is a modern fork of zlib that in
 most cases will be more effective. Though it will add an externel dependency on
 [cmake].
 
-If both are enabled or if the `zlib` feature of [flate2] is enabled anywhere in 
+If both are enabled or if the `zlib` feature of [flate2] is enabled anywhere in
 the dependency tree it will make use of that instead of [zlib-ng].
 
 ## Example

--- a/src/chapter_1_crates/section_4_cache_inmemory.md
+++ b/src/chapter_1_crates/section_4_cache_inmemory.md
@@ -3,14 +3,6 @@
 Twilight includes an in-process-memory cache. It's responsible for processing
 events and caching things like guilds, channels, users, and voice states.
 
-## Installation
-
-Add the following to your Cargo.toml:
-
-```toml
-[dependencies]
-twilight-cache-inmemory = "0.1"
-```
 
 ## Examples
 

--- a/src/chapter_1_crates/section_5_command_parser.md
+++ b/src/chapter_1_crates/section_5_command_parser.md
@@ -13,15 +13,6 @@ names, prefixes, and ignored guilds and users. The parser parses out commands
 matching an available command and prefix and provides the command arguments to
 you.
 
-## Installation
-
-Add the following to your Cargo.toml:
-
-```toml
-[dependencies]
-twilight-command-parser = "0.1"
-```
-
 ## Examples
 
 A simple parser for a bot with one prefix (`"!"`) and two commands, `"echo"`

--- a/src/chapter_1_crates/section_6_standby.md
+++ b/src/chapter_1_crates/section_6_standby.md
@@ -7,14 +7,6 @@ application-level state or event stream may not suit your use case. It may be
 cleaner to wait for a reaction inline to your function. This is where Standby
 comes in.
 
-## Installation
-
-Add the following to your `Cargo.toml`:
-
-```toml
-twilight-standby = "0.1"
-```
-
 ## Examples
 
 Wait for a message in channel 123 by user 456 with the content "test":

--- a/src/chapter_1_crates/section_7_first_party/section_1_embed_builder.md
+++ b/src/chapter_1_crates/section_7_first_party/section_1_embed_builder.md
@@ -6,14 +6,6 @@ when creating or updating messages.
 With this library, you can create mentions for various types, such as users,
 emojis, roles, members, or channels.
 
-## Installation
-
-Add the following to your `Cargo.toml`:
-
-```toml
-twilight-embed-builder = "0.1"
-```
-
 ## Examples
 
 Build a simple embed:

--- a/src/chapter_1_crates/section_7_first_party/section_2_mention.md
+++ b/src/chapter_1_crates/section_7_first_party/section_2_mention.md
@@ -5,14 +5,6 @@
 With this library, you can create mentions for various resources, such as users,
 emojis, roles, members, or channels.
 
-## Installation
-
-Add the following to your `Cargo.toml`:
-
-```toml
-twilight-mention = "0.1"
-```
-
 ## Examples
 
 Create a mention formatter for a user ID, and then format it in a message:

--- a/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
+++ b/src/chapter_1_crates/section_7_first_party/section_3_lavalink.md
@@ -8,14 +8,6 @@ conveniently using players to send events and retrieve information for each
 guild, and an HTTP module for creating requests using the http crate and
 providing models to deserialize their responses.
 
-## Installation
-
-Add the following to your `Cargo.toml`:
-
-```toml
-twilight-lavalink = "0.1"
-```
-
 ## Examples
 
 Create a [client], add a [node], and give events to the client to [process]

--- a/src/chapter_1_crates/section_7_first_party/section_4_util.md
+++ b/src/chapter_1_crates/section_7_first_party/section_4_util.md
@@ -5,13 +5,6 @@ ecosystem that do not fit in any other crate. Currently, it contains
 a trait to make extracting data from Discord identifiers (Snowflakes)
 easier.
 
-## Installation
-
-Add the following to your `Cargo.toml`:
-```toml
-twilight-util = { features = ["snowflake"], version = "0.1" }
-```
-
 ## Examples
 The snowflake trait can be used like this
 ```rust

--- a/src/chapter_1_crates/section_7_first_party/section_5_gateway_queue.md
+++ b/src/chapter_1_crates/section_7_first_party/section_5_gateway_queue.md
@@ -4,13 +4,6 @@
 the [gateway] to ratelimit `identify` calls. Developers should prefer to use the
 re-exports of these crates through the [gateway].
 
-## Installation
-
-Add the following yo your `Cargo.toml`:
-```toml
-twilight-gateway-queue = "0.1.0"
-```
-
 ## Links
 
 *source*: <https://github.com/twilight-rs/twilight/tree/trunk/gateway/queue>


### PR DESCRIPTION
Remove installation notes for all of the crates' pages. It's clear for anyone with some experience with Rust how to install them, and this means we don't have to keep track of versions anymore.