### PR TITLE
gitignore: add test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 book
+tests/target/
+tests/Cargo.lock
+tests/libtest.rmeta


### PR DESCRIPTION
Add the following test artifacts to the .gitignore as these shouldn't be committed:

- tests/target/
- tests/Cargo.lock
- tests/libtest.rmeta