### PR TITLE
support: document msrv of rust 1.48+

### DIFF
--- a/src/support.md
+++ b/src/support.md
@@ -15,7 +15,7 @@ The API documentation is [also available][api docs].
 
 ### Supported Rust Versions
 
-Twilight currently supports the latest stable Rust version.
+Twilight currently supports an MSRV of Rust 1.48+.
 
 ### Breaking Changes
 


### PR DESCRIPTION
Document an MSRV of Rust 1.48+ in the Support section.

The MSRV was added in [PR #636].

[PR #636]: https://github.com/twilight-rs/twilight/pull/636